### PR TITLE
build fixes

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,8 +7,6 @@ if [[ $(uname) == Darwin ]]; then
     SO=dylib
 else
     SO=so
-    # -lpthread needed for ptscotch
-    LDFLAGS="-lpthread $LDFLAGS"
 fi
 
 $PYTHON ./configure \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,13 +18,13 @@ build:
   number: {{build}}
   binary_relocation: true
   detect_binary_files_with_prefix: true
-  skip: true  # [win or py3k]
+  skip: true  # [win]
   features:
     - blas_{{blas}}
 
 requirements:
   build:
-    - python
+    - python 2.7.*
     - cmake
     - blas 1.* {{blas}}
     - {{mpi}} {{req[mpi]}}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 0 %}
+{% set build = 1 %}
 {% set version = '3.7.4' %}
 {% set sha256 = '92aab64b7fd9c8491eefffd4ccebe5c8a0ba90a464e766db453e8fe96fd332e9' %}
 {% set blas = os.environ.get('BLAS') or 'openblas' %}


### PR DESCRIPTION
- remove `-lpthread` from build.sh, which was only needed due to something wrong in ptscotch,
  which has since been fixed.
- specify python 2 in requirements.build instead of build.skip,
  avoiding the need to set CONDA_PY=27