### PR TITLE
pin openblas version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Summary: PETSc: Portable, Extensible Toolkit for Scientific Computation
 
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/petsc-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/petsc-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/petsc-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/petsc-feedstock)
+Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/petsc/badges/version.svg)](https://anaconda.org/conda-forge/petsc)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/petsc/badges/downloads.svg)](https://anaconda.org/conda-forge/petsc)
+
 Installing petsc
 ================
 
@@ -31,7 +43,6 @@ It is possible to list all of the versions of `petsc` available on your platform
 ```
 conda search petsc --channel conda-forge
 ```
-
 
 
 About conda-forge
@@ -67,18 +78,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/petsc-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/petsc-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/petsc-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/petsc-feedstock)
-Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/petsc/badges/version.svg)](https://anaconda.org/conda-forge/petsc)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/petsc/badges/downloads.svg)](https://anaconda.org/conda-forge/petsc)
 
 
 Updating petsc-feedstock

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 1 %}
+{% set build = 2 %}
 {% set version = '3.7.4' %}
 {% set sha256 = '92aab64b7fd9c8491eefffd4ccebe5c8a0ba90a464e766db453e8fe96fd332e9' %}
 {% set blas = os.environ.get('BLAS') or 'openblas' %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,6 +2,7 @@
 {% set version = '3.7.4' %}
 {% set sha256 = '92aab64b7fd9c8491eefffd4ccebe5c8a0ba90a464e766db453e8fe96fd332e9' %}
 {% set blas = os.environ.get('BLAS') or 'openblas' %}
+{% set openblas_version = '0.2.19' %}
 {% set mpi = os.environ.get('MPI') or 'mpich' %}
 {% set req = {'mpich':'>=3.2', 'openmpi':'>=1.10'} %}
 
@@ -27,12 +28,18 @@ requirements:
     - python 2.7.*
     - cmake
     - blas 1.* {{blas}}
+    {% if blas == 'openblas' %}
+    - openblas {{openblas_version}}
+    {% endif %}
     - {{mpi}} {{req[mpi]}}
     - ptscotch
     - suitesparse 4.5.*
     - toolchain
   run:
     - blas 1.* {{blas}}
+    {% if blas == 'openblas' %}
+    - openblas {{openblas_version}}
+    {% endif %}
     - {{mpi}} {{req[mpi]}}
     - ptscotch
     - suitesparse 4.5.*


### PR DESCRIPTION
downstream builds (fenics) are failing because PETSc is linked to 0.2.18, while downstream builds are picking up 0.2.19 via loose `blas` dependency.

The only solution I see is pinning the openblas version.