### PR TITLE
pin suitesparse version to patch-level

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 3 %}
+{% set build = 4 %}
 {% set version = '3.7.4' %}
 {% set sha256 = '92aab64b7fd9c8491eefffd4ccebe5c8a0ba90a464e766db453e8fe96fd332e9' %}
 {% set blas = os.environ.get('BLAS') or 'openblas' %}
@@ -33,7 +33,7 @@ requirements:
     {% endif %}
     - {{mpi}} {{req[mpi]}}
     - ptscotch
-    - suitesparse 4.5.*
+    - suitesparse 4.5.4
     - toolchain
   run:
     - blas 1.* {{blas}}
@@ -42,7 +42,7 @@ requirements:
     {% endif %}
     - {{mpi}} {{req[mpi]}}
     - ptscotch
-    - suitesparse 4.5.*
+    - suitesparse 4.5.4
 
 test:
   source_files:


### PR DESCRIPTION
libs are linked all the way to the patch file (@rpath/libsuitesparseconfig.4.5.3.dylib) rather than the top-level lib (@rpath/libsuitesparseconfig.dylib)

So while a patch-level update to suitesparse *shouldn’t* break anything, the linkage breaks because it's pointing to the patch-specific path.

I *think* this should be fixed in the suitesparse package (via `install_name_tool` on macOS), but I'm not sure.

cf https://github.com/conda-forge/mshr-feedstock/issues/5