### PR TITLE
fix petsc link macros

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build = 0 %}
+{% set build = 1 %}
 {% set version = '3.8.3' %}
 {% set sha256 = '5509e35d55d5ce9e92dbe7a83f5e509865aea2a4cc2d9f16f72b7a5ceaafed96' %}
 {% set blas = os.environ.get('BLAS') or 'openblas' %}
@@ -14,6 +14,8 @@ source:
   fn: petsc-{{version}}.tar.gz
   url: http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-{{version}}.tar.gz
   sha256: {{sha256}}
+  patches:
+    - petsc-lib.patch
 
 build:
   skip: true  # [win]

--- a/recipe/petsc-lib.patch
+++ b/recipe/petsc-lib.patch
@@ -1,0 +1,31 @@
+--- config/PETSc/Configure.py.orig	2018-01-30 19:42:31.000000000 +0100
++++ config/PETSc/Configure.py	2018-01-30 19:44:28.000000000 +0100
+@@ -416,17 +416,17 @@
+       self.addMakeMacro('PETSC_WITH_EXTERNAL_LIB',self.alllibs)
+       self.addDefine('USE_SINGLE_LIBRARY', '1')
+       if self.sharedlibraries.useShared:
+-        self.addMakeMacro('PETSC_SYS_LIB','${C_SH_LIB_PATH} ${PETSC_WITH_EXTERNAL_LIB}')
+-        self.addMakeMacro('PETSC_VEC_LIB','${C_SH_LIB_PATH} ${PETSC_WITH_EXTERNAL_LIB}')
+-        self.addMakeMacro('PETSC_MAT_LIB','${C_SH_LIB_PATH} ${PETSC_WITH_EXTERNAL_LIB}')
+-        self.addMakeMacro('PETSC_DM_LIB','${C_SH_LIB_PATH} ${PETSC_WITH_EXTERNAL_LIB}')
+-        self.addMakeMacro('PETSC_KSP_LIB','${C_SH_LIB_PATH} ${PETSC_WITH_EXTERNAL_LIB}')
+-        self.addMakeMacro('PETSC_SNES_LIB','${C_SH_LIB_PATH} ${PETSC_WITH_EXTERNAL_LIB}')
+-        self.addMakeMacro('PETSC_TS_LIB','${C_SH_LIB_PATH} ${PETSC_WITH_EXTERNAL_LIB}')
+-        self.addMakeMacro('PETSC_TAO_LIB','${C_SH_LIB_PATH} ${PETSC_WITH_EXTERNAL_LIB}')
+-        self.addMakeMacro('PETSC_CHARACTERISTIC_LIB','${C_SH_LIB_PATH} ${PETSC_WITH_EXTERNAL_LIB}')
+-        self.addMakeMacro('PETSC_LIB','${C_SH_LIB_PATH} ${PETSC_WITH_EXTERNAL_LIB}')
+-        self.addMakeMacro('PETSC_CONTRIB','${C_SH_LIB_PATH} ${PETSC_WITH_EXTERNAL_LIB}')
++        self.addMakeMacro('PETSC_SYS_LIB','${C_SH_LIB_PATH} ${PETSC_LIB_BASIC}')
++        self.addMakeMacro('PETSC_VEC_LIB','${C_SH_LIB_PATH} ${PETSC_LIB_BASIC}')
++        self.addMakeMacro('PETSC_MAT_LIB','${C_SH_LIB_PATH} ${PETSC_LIB_BASIC}')
++        self.addMakeMacro('PETSC_DM_LIB','${C_SH_LIB_PATH} ${PETSC_LIB_BASIC}')
++        self.addMakeMacro('PETSC_KSP_LIB','${C_SH_LIB_PATH} ${PETSC_LIB_BASIC}')
++        self.addMakeMacro('PETSC_SNES_LIB','${C_SH_LIB_PATH} ${PETSC_LIB_BASIC}')
++        self.addMakeMacro('PETSC_TS_LIB','${C_SH_LIB_PATH} ${PETSC_LIB_BASIC}')
++        self.addMakeMacro('PETSC_TAO_LIB','${C_SH_LIB_PATH} ${PETSC_LIB_BASIC}')
++        self.addMakeMacro('PETSC_CHARACTERISTIC_LIB','${C_SH_LIB_PATH} ${PETSC_LIB_BASIC}')
++        self.addMakeMacro('PETSC_LIB','${C_SH_LIB_PATH} ${PETSC_LIB_BASIC}')
++        self.addMakeMacro('PETSC_CONTRIB','${C_SH_LIB_PATH} ${PETSC_LIB_BASIC}')
+       else:
+         self.addMakeMacro('PETSC_SYS_LIB','${PETSC_WITH_EXTERNAL_LIB}')
+         self.addMakeMacro('PETSC_VEC_LIB','${PETSC_WITH_EXTERNAL_LIB}')


### PR DESCRIPTION
linking petsc should only be `-L$PREFIX/lib -lpetsc`, not pulling in all transitive dependency libraries, which petsc itself already links as a shared library.

This was revealed because PETSC_WITH_EXTERNAL_LIB includes more than all runtime libraries, so downstream packages that use these variables (slepc) fail to build due to missing links of libraries that don’t exist and are not needed.

This fixes the slepc build in https://github.com/conda-forge/slepc-feedstock/pull/7, which should not have failed, despite being superceded by https://github.com/conda-forge/slepc-feedstock/pull/8.