### PR TITLE
conda-build 3 fixes

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,7 +22,7 @@ python ./configure \
   --FOPTFLAGS=-O3 \
   --with-clib-autodetect=0 \
   --with-cxxlib-autodetect=0 \
-  --with-fortranlib-autodetect=0 \
+  --with-fortranlib-autodetect=1 \
   --with-debugging=0 \
   --with-blas-lapack-lib=libopenblas${SHLIB_EXT} \
   --with-hwloc=0 \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,8 +10,11 @@ if [[ $(uname) == Linux ]]; then
 fi
 
 python ./configure \
-  CPPFLAGS="$CPPFLAGS" \
+  CC="mpicc" \
+  CXX="mpicxx" \
+  FC="mpifort" \
   CFLAGS="$CFLAGS" \
+  CPPFLAGS="$CPPFLAGS" \
   CXXFLAGS="$CXXFLAGS" \
   LDFLAGS="$LDFLAGS" \
   --COPTFLAGS=-O3 \
@@ -19,7 +22,7 @@ python ./configure \
   --FOPTFLAGS=-O3 \
   --with-clib-autodetect=0 \
   --with-cxxlib-autodetect=0 \
-  --with-fortranlib-autodetect=1 \
+  --with-fortranlib-autodetect=0 \
   --with-debugging=0 \
   --with-blas-lapack-lib=libopenblas${SHLIB_EXT} \
   --with-hwloc=0 \
@@ -36,12 +39,24 @@ python ./configure \
   --with-x=0 \
   --prefix=$PREFIX
 
-sedinplace() { [[ $(uname) == Darwin ]] && sed -i "" $@ || sed -i"" $@; }
+sedinplace() {
+  if [[ $(uname) == Darwin ]]; then
+    sed -i "" $@
+  else
+    sed -i"" $@
+  fi
+}
+
 for path in $PETSC_DIR $PREFIX; do
     sedinplace s%$path%\${PETSC_DIR}%g $PETSC_ARCH/include/petsc*.h
 done
 
 make
+
+for f in $(grep -l build_env -R "${PETSC_ARCH}/lib"); do
+  echo "fixing build prefix in $f"
+  sedinplace s%${BUILD_PREFIX}%${PREFIX}%g $f
+done
 
 # FIXME: Workaround mpiexec setting O_NONBLOCK in std{in|out|err}
 # See https://github.com/conda-forge/conda-smithy/pull/337

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -53,7 +53,7 @@ done
 
 make
 
-for f in $(grep -l build_env -R "${PETSC_ARCH}/lib"); do
+for f in $(grep -l build_env -R "${PETSC_ARCH}/lib/petsc"); do
   echo "fixing build prefix in $f"
   sedinplace s%${BUILD_PREFIX}%${PREFIX}%g $f
 done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set version = "3.9.2" %}
 {% set sha256 = '65100189796f05991bb2e746f56eec27f8425f6eb901f8f08459ffd2a5e6c69a' %}
-{% set blas = os.environ.get('BLAS') or 'openblas' %}
 
 package:
   name: petsc
@@ -13,22 +12,19 @@ source:
 
 build:
   skip: true  # [win]
-  number: 1
-  features:
-    - blas_{{ blas }}
+  number: 2
+  run_exports:
+    - {{ pin_subpackage('petsc', max_pin='x.x')}}
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
-    - python 2.7.*
   host:
+    - python 2.7.*
     - cmake
-    - blas 1.* {{ blas }}
-    {% if blas == 'openblas' %}
     - openblas
-    {% endif %}
     - {{ mpi }}
     - hypre
     - metis
@@ -38,10 +34,7 @@ requirements:
     - mumps-mpi
     - suitesparse
   run:
-    - blas 1.* {{ blas }}
-    {% if blas == 'openblas' %}
     - openblas
-    {% endif %}
     - {{ mpi }}
     - hypre
     - metis


### PR DESCRIPTION
some references to the build env were remaining in the built result, e.g. due to references to the compiler. This caused downstream packages using petscvariables, etc. to fail to find things like libgcc

- find and remove references to the build env with `sedinplace`
- specify mpi compilers
- put python in the host env
- <del>disable fortranlib-autodetect, which picked up spurious libraries</del>
- remove blas feature from conda-forge feedback on gitter