### PR TITLE
scrub some spurious paths from split envs

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -41,14 +41,23 @@ python ./configure \
 
 sedinplace() {
   if [[ $(uname) == Darwin ]]; then
-    sed -i "" $@
+    sed -i "" "$@"
   else
-    sed -i"" $@
+    sed -i"" "$@"
   fi
 }
 
 for path in $PETSC_DIR $PREFIX; do
     sedinplace s%$path%\${PETSC_DIR}%g $PETSC_ARCH/include/petsc*.h
+done
+
+# remove abspath of build_env/bin/python
+sedinplace "s%${BUILD_PREFIX}/bin/python%/usr/bin/env python2%g" $PETSC_ARCH/lib/petsc/conf/reconfigure-arch-conda-c-opt.py
+sedinplace "s%${BUILD_PREFIX}/bin/python%python2%g" $PETSC_ARCH/lib/petsc/conf/petscvariables
+
+# remove spurious linking of libgcc_ext brought in from FORTRAN_IMPLICIT_LIBS
+for f in lib/petsc/conf/petscvariables lib/pkgconfig/PETSc.pc; do
+  sedinplace "s@\-lgcc_ext[^ ]*@@g" "$PETSC_ARCH/$f"
 done
 
 make

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,9 @@ source:
 
 build:
   skip: true  # [win]
-  number: 3
+  number: 4
+  # we didn't need to add this feature,
+  # but we cannot remove it until blas mpkg drops track_features
   features:
     - blas_openblas
   run_exports:
@@ -23,8 +25,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
-  host:
     - python 2.7.*
+  host:
     - cmake
     - openblas
     - {{ mpi }}


### PR DESCRIPTION
- use just `python2` for python interpreter, not absolute path, which is unnecessarily fragile
- remove spurious linking of `libgcc_ext.10.5` pulled in by FORTRAN_IMPLICIT_LIBS, which isn’t needed and causes failures if `gcc` package isn’t present in host env