### PR TITLE
disable --with-fortranlib-autodetect

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -17,12 +17,13 @@ python ./configure \
   CPPFLAGS="$CPPFLAGS" \
   CXXFLAGS="$CXXFLAGS" \
   LDFLAGS="$LDFLAGS" \
+  LIBS="-lmpifort -lgfortran" \
   --COPTFLAGS=-O3 \
   --CXXOPTFLAGS=-O3 \
   --FOPTFLAGS=-O3 \
   --with-clib-autodetect=0 \
   --with-cxxlib-autodetect=0 \
-  --with-fortranlib-autodetect=0 LIBS="-lgfortran" \
+  --with-fortranlib-autodetect=0 \
   --with-debugging=0 \
   --with-blas-lapack-lib=libopenblas${SHLIB_EXT} \
   --with-hwloc=0 \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,6 +9,12 @@ if [[ $(uname) == Linux ]]; then
     export LDFLAGS="-pthread $LDFLAGS"
 fi
 
+if [[ $mpi == "openmpi" ]]; then
+  export LIBS="-lmpi_mpifh -lgfortran"
+elif [[ $mpi == "mpich" ]]; then
+  export LIBS="-lmpifort -lgfortran"
+fi
+
 python ./configure \
   CC="mpicc" \
   CXX="mpicxx" \
@@ -17,7 +23,7 @@ python ./configure \
   CPPFLAGS="$CPPFLAGS" \
   CXXFLAGS="$CXXFLAGS" \
   LDFLAGS="$LDFLAGS" \
-  LIBS="-lmpifort -lgfortran" \
+  LIBS="$LIBS" \
   --COPTFLAGS=-O3 \
   --CXXOPTFLAGS=-O3 \
   --FOPTFLAGS=-O3 \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -56,9 +56,12 @@ done
 sedinplace "s%${BUILD_PREFIX}/bin/python%/usr/bin/env python2%g" $PETSC_ARCH/lib/petsc/conf/reconfigure-arch-conda-c-opt.py
 sedinplace "s%${BUILD_PREFIX}/bin/python%python2%g" $PETSC_ARCH/lib/petsc/conf/petscvariables
 
-# remove spurious linking of libgcc_ext brought in from FORTRAN_IMPLICIT_LIBS
+# verify that gcc_ext isn't linked
 for f in lib/petsc/conf/petscvariables lib/pkgconfig/PETSc.pc; do
-  sedinplace "s@\-lgcc_ext[^ ]*@@g" "$PETSC_ARCH/$f"
+  if grep gcc_ext $f; then
+    echo "gcc_ext found in $f"
+    exit 1
+  fi
 done
 
 make

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -37,7 +37,7 @@ python ./configure \
   --with-scalapack=1 \
   --with-suitesparse=1 \
   --with-x=0 \
-  --prefix=$PREFIX
+  --prefix=$PREFIX || (cat configure.log && exit 1)
 
 sedinplace() {
   if [[ $(uname) == Darwin ]]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,7 +22,7 @@ python ./configure \
   --FOPTFLAGS=-O3 \
   --with-clib-autodetect=0 \
   --with-cxxlib-autodetect=0 \
-  --with-fortranlib-autodetect=1 \
+  --with-fortranlib-autodetect=0 LIBS="-lgfortran" \
   --with-debugging=0 \
   --with-blas-lapack-lib=libopenblas${SHLIB_EXT} \
   --with-hwloc=0 \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "3.9.2" %}
-{% set sha256 = '65100189796f05991bb2e746f56eec27f8425f6eb901f8f08459ffd2a5e6c69a' %}
+{% set version = "3.9.3" %}
+{% set sha256 = '8828fe1221f038d78a8eee3325cdb22ad1055a2f0671871815ee9f47365f93bb' %}
 
 package:
   name: petsc
@@ -12,7 +12,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 4
+  number: 0
   # we didn't need to add this feature,
   # but we cannot remove it until blas mpkg drops track_features
   features:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 0
+  number: 1
   # we didn't need to add this feature,
   # but we cannot remove it until blas mpkg drops track_features
   features:


### PR DESCRIPTION
since it pulls in spurious libraries like gcc_ext.10.5

instead, set `LIBS="-l$mpifort -lgfortran"` where `$mpifort = mpifort` on mpich and `mpi_mpifh` on openmpi