### PR TITLE
scrub fdebug-prefix from compile flags

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,6 +16,11 @@ if [[ $(uname) == Linux ]]; then
     export FFLAGS="${FFLAGS:-} -Wl,--no-as-needed"
 fi
 
+# scrub debug-prefix-map args, which cause problems in pkg-config
+export CFLAGS=$(echo ${CFLAGS:-} | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
+export CXXFLAGS=$(echo ${CXXFLAGS:-} | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
+export FFLAGS=$(echo ${FFLAGS:-} | sed -E 's@\-fdebug\-prefix\-map[^ ]*@@g')
+
 if [[ $mpi == "openmpi" ]]; then
   export LIBS="-Wl,-rpath,$PREFIX/lib -lmpi_mpifh -lgfortran"
 elif [[ $mpi == "mpich" ]]; then
@@ -30,7 +35,7 @@ python ./configure \
   CFLAGS="$CFLAGS" \
   CPPFLAGS="$CPPFLAGS" \
   CXXFLAGS="$CXXFLAGS" \
-  FFLAGS="${FFLAGS:-}" \
+  FFLAGS="$FFLAGS" \
   LDFLAGS="$LDFLAGS" \
   LIBS="$LIBS" \
   --COPTFLAGS=-O3 \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 1001
+  number: 1002
   # we didn't need to add this feature,
   # but we cannot remove it until blas mpkg drops track_features
   features:
@@ -50,6 +50,7 @@ requirements:
 
 test:
   requires:
+    - pkg-config
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
@@ -58,8 +59,9 @@ test:
     - tests/ex1f.F90
     - tests/makefile
   commands:
-    - conda inspect objects  petsc  # [osx]
-    - conda inspect linkages petsc  # [not win]
+    - pkg-config --validate PETSc
+    - pkg-config --cflags PETSc
+    - pkg-config --libs PETSc
 
 about:
   home: http://www.mcs.anl.gov/petsc/


### PR DESCRIPTION
these create invalid pkg-config files, and I suspect don’t do what they intend anyway, since they leave unexpanded environment variables in the args.

The pkg-config files are tested now, which should confirm the fix.