### PR TITLE
install config examples

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -100,6 +100,8 @@ make check MPIEXEC="${RECIPE_DIR}/mpiexec.sh"
 
 make install
 
-rm -fr $PREFIX/share/petsc/examples
+du -hs $PREFIX/share/petsc/examples/*
+rm -fr $PREFIX/share/petsc/examples/src
+du -hs $PREFIX/share/petsc/datafiles/*
 rm -fr $PREFIX/share/petsc/datafiles
 find   $PREFIX/lib/petsc -name '*.pyc' -delete

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,10 +14,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 0
-  # we didn't need to add this feature,
-  # but we cannot remove it until blas mpkg drops track_features
-  features:
+  number: 1
   run_exports:
     - {{ pin_subpackage('petsc', max_pin='x.x')}}
 


### PR DESCRIPTION
examples/src is most of the space we want to save and slepc 3.11 needs the config example to build

cf https://github.com/conda-forge/slepc-feedstock/pull/24