### PR TITLE
exclude cppflags from pkg-config cflags

### DIFF
--- a/recipe/check-version.patch
+++ b/recipe/check-version.patch
@@ -1,0 +1,71 @@
+From 53a5e9c0558560048914cf899e06b52f068f9586 Mon Sep 17 00:00:00 2001
+From: Satish Balay <balay@mcs.anl.gov>
+Date: Tue, 22 Oct 2019 17:15:12 -0500
+Subject: [PATCH] configure: pkg version check: attempt to make it robust
+ against cpp spliting up lines or adding spaces
+
+# 4 "/tmp/petsc-gUHwey/config.packages.hypre/conftest.c" 2
+version=
+# 4 "/tmp/petsc-gUHwey/config.packages.hypre/conftest.c" 3
+       "2.17.0"
+
+Reported-by: Justin Herter <herter@kairospower.com>
+---
+ config/BuildSystem/config/package.py | 18 ++++++++++--------
+ 1 file changed, 10 insertions(+), 8 deletions(-)
+
+diff --git a/config/BuildSystem/config/package.py b/config/BuildSystem/config/package.py
+index 63ae9286d5..c36bcbafed 100644
+--- a/config/BuildSystem/config/package.py
++++ b/config/BuildSystem/config/package.py
+@@ -2,6 +2,7 @@ from __future__ import generators
+ import config.base
+ 
+ import os
++import re
+ 
+ try:
+   from hashlib import md5 as new_md5
+@@ -997,7 +998,7 @@ If its a remote branch, use: origin/'+self.gitcommit+' for commit.')
+     else:
+       self.pushLanguage(self.defaultLanguage)
+     try:
+-      output = self.outputPreprocess('#include "'+self.versioninclude+'"\nversion='+self.versionname+'\n')
++      output = self.outputPreprocess('#include "'+self.versioninclude+'"\n;petscpkgver('+self.versionname+');\n')
+     except:
+       self.log.write('For '+self.package+' unable to run preprocessor to obtain version information, skipping version check\n')
+       self.popLanguage()
+@@ -1005,14 +1006,16 @@ If its a remote branch, use: origin/'+self.gitcommit+' for commit.')
+       return
+     self.popLanguage()
+     self.compilers.CPPFLAGS = oldFlags
+-    loutput = output.split('\n')
++    #strip #lines
++    output = re.sub('#.*\n','\n',output)
++    #strip newlines,spaces,quotes
++    output = re.sub('[\n "]*','',output)
++    #now split over ';'
++    loutput = output.split(';')
+     version = ''
+     for i in loutput:
+-      if i.startswith('version='):
+-        version = i[8:]
+-        break
+-      if i.startswith('version ='):
+-        version = i[9:]
++      if i.find('petscpkgver') >=0:
++        version = i.split('(')[1].split(')')[0]
+         break
+     if not version:
+       self.log.write('For '+self.package+' unable to find version information: output below, skipping version check\n')
+@@ -1020,7 +1023,6 @@ If its a remote branch, use: origin/'+self.gitcommit+' for commit.')
+       if self.requiresversion:
+         raise RuntimeError('Configure must be able to determined the version information for '+self.name+'. It was unable to, please send configure.log to petsc-maint@mcs.anl.gov')
+       return
+-    version = version.replace(' ','').replace('\"','')
+     try:
+       self.foundversion = self.versionToStandardForm(version)
+       self.version_tuple = self.versionToTuple(self.foundversion)
+-- 
+2.22.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
   patches:
     - ignore-not-invalid.patch
     - no-cppflags-in-pkgconfig-cflags.patch
+    - check-version.patch
 
 build:
   skip: true  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,10 +13,11 @@ source:
   sha256: {{ sha256 }}
   patches:
     - ignore-not-invalid.patch
+    - no-cppflags-in-pkgconfig-cflags.patch
 
 build:
   skip: true  # [win]
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('petsc', max_pin='x.x')}}
 

--- a/recipe/no-cppflags-in-pkgconfig-cflags.patch
+++ b/recipe/no-cppflags-in-pkgconfig-cflags.patch
@@ -1,0 +1,25 @@
+From 5d8ee35b4fddbdd644ae93d4ba6f3bc2e9fc5a39 Mon Sep 17 00:00:00 2001
+From: Min RK <benjaminrk@gmail.com>
+Date: Tue, 19 Nov 2019 12:24:18 +0100
+Subject: [PATCH] don't include cppflags in Cflags in pkg-config output
+
+---
+ config/PETSc/Configure.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/config/PETSc/Configure.py b/config/PETSc/Configure.py
+index 363c5d6550..0a65204344 100644
+--- a/config/PETSc/Configure.py
++++ b/config/PETSc/Configure.py
+@@ -178,7 +178,7 @@ class Configure(config.base.Configure):
+     fd.write('Name: PETSc\n')
+     fd.write('Description: Library to solve ODEs and algebraic equations\n')
+     fd.write('Version: %s\n' % self.petscdir.version)
+-    fd.write('Cflags: ' + ' '.join([self.setCompilers.CPPFLAGS] + cflags_inc) + '\n')
++    fd.write('Cflags: ' + ' '.join(cflags_inc) + '\n')
+     fd.write('Libs: '+self.libraries.toStringNoDupes(['-L${libdir}', self.petsclib], with_rpath=False)+'\n')
+     # Remove RPATH flags from library list.  User can add them using
+     # pkg-config --variable=ldflag_rpath and pkg-config --libs-only-L
+-- 
+2.23.0
+

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -2,6 +2,9 @@
 set -e
 
 export PETSC_DIR=${PREFIX}
+
+pkg-config --cflags PETSc | grep -v isystem
+
 cd tests
 make ex1
 make ex1f


### PR DESCRIPTION
creates invalid and inappropriate cflags, e.g. including `-isystem` which shouldn't be propagated to downstream packages