### PR TITLE
add runtime dependency on blas-devel

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('petsc', max_pin='x.x') }}
 
@@ -30,6 +30,7 @@ requirements:
     - pkg-config
     - python
   host:
+    - blas-devel
     - libblas
     - libcblas
     - liblapack
@@ -49,6 +50,7 @@ requirements:
     - suitesparse
     - hdf5
   run:
+    - blas-devel
     - {{ mpi }}
     - hypre
     - metis


### PR DESCRIPTION
allow for the removal of `libblas.so` etc. from the exported dependencies when they are linked

cf https://github.com/conda-forge/blas-feedstock/issues/29