### PR TITLE
petsc has stricter requirements on mpi version than their run_exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.17.2" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 {% set mpi = mpi or 'mpich' %}
 {% if scalar == "real" %}
@@ -17,6 +17,7 @@ source:
     - ignore-not-invalid.patch
     - no-cppflags-in-pkgconfig-cflags.patch
     - no-macos-mkdtemp-fix.patch
+    - mpi-check.patch
 
 build:
   skip: true  # [win]

--- a/recipe/mpi-check.patch
+++ b/recipe/mpi-check.patch
@@ -1,0 +1,37 @@
+From 1c2847649e9d1d4a0c1c58f7a3b28ee889aec64b Mon Sep 17 00:00:00 2001
+From: Min RK <benjaminrk@gmail.com>
+Date: Thu, 19 May 2022 11:25:04 +0200
+Subject: [PATCH] allow more compatible mpi versions
+
+accept mpich 4.1 when built with 4.0, etc.
+
+When build against x.y.z, accept any version >=x.y.z,<x+1.0.0
+
+mpich, openmpi claim backward-compatibility for minor releases
+---
+ include/petscsys.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/petscsys.h b/include/petscsys.h
+index 3531675a74..fa47724929 100644
+--- a/include/petscsys.h
++++ b/include/petscsys.h
+@@ -94,13 +94,13 @@
+ #elif defined(PETSC_HAVE_MPICH_NUMVERSION)
+ #  if !defined(MPICH_NUMVERSION) || defined(MVAPICH2_NUMVERSION) || defined(I_MPI_NUMVERSION)
+ #    error "PETSc was configured with MPICH but now appears to be compiling using a non-MPICH mpi.h"
+-#  elif (MPICH_NUMVERSION/100000 != PETSC_HAVE_MPICH_NUMVERSION/100000) || (MPICH_NUMVERSION%100000/1000 < PETSC_HAVE_MPICH_NUMVERSION%100000/1000)
++#  elif (MPICH_NUMVERSION/100000000 != PETSC_HAVE_MPICH_NUMVERSION/100000000) || (MPICH_NUMVERSION/100000 < PETSC_HAVE_MPICH_NUMVERSION/100000) || (MPICH_NUMVERSION/100000 == PETSC_HAVE_MPICH_NUMVERSION/100000 && MPICH_NUMVERSION%100000/1000 < PETSC_HAVE_MPICH_NUMVERSION%100000/1000)
+ #    error "PETSc was configured with one MPICH mpi.h version but now appears to be compiling using a different MPICH mpi.h version"
+ #  endif
+ #elif defined(PETSC_HAVE_OMPI_MAJOR_VERSION)
+ #  if !defined(OMPI_MAJOR_VERSION)
+ #    error "PETSc was configured with OpenMPI but now appears to be compiling using a non-OpenMPI mpi.h"
+-#  elif (OMPI_MAJOR_VERSION != PETSC_HAVE_OMPI_MAJOR_VERSION) || (OMPI_MINOR_VERSION != PETSC_HAVE_OMPI_MINOR_VERSION) || (OMPI_RELEASE_VERSION < PETSC_HAVE_OMPI_RELEASE_VERSION)
++#  elif (OMPI_MAJOR_VERSION != PETSC_HAVE_OMPI_MAJOR_VERSION) || (OMPI_MINOR_VERSION < PETSC_HAVE_OMPI_MINOR_VERSION) || (OMPI_MINOR_VERSION == PETSC_HAVE_OMPI_MINOR_VERSION && OMPI_RELEASE_VERSION < PETSC_HAVE_OMPI_RELEASE_VERSION)
+ #    error "PETSc was configured with one OpenMPI mpi.h version but now appears to be compiling using a different OpenMPI mpi.h version"
+ #  endif
+ #  define PETSC_MPI_COMM_FMT "p"
+-- 
+2.35.3
+


### PR DESCRIPTION
mpich, openmpi have looser ABI compatibility expressed in their run_exports, but petsc has its own, additional checks [in petscsys.h](https://github.com/petsc/petsc/blob/main/include/petscsys.h#L89-L100) when compiling against petsc, asserting major-minor-version match, causing build to fail (incorrectly, I think).

Simple solution (this pr) is to accept petsc's asserted compatibility and apply it to the package. Alternative is to remove the check and trust the mpi packages' expressed compatibility.

If it truly is wrong _in general_, we can submit a patch upstream to relax the compatibility check to accept more correct compatibility (>=x.y.z, <x+1.0.0), but I think it's simpler to just accept that petsc wants to be strict.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
