### PR TITLE
specify scalar in run_exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.17.2" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 {% set mpi = mpi or 'mpich' %}
 {% if scalar == "real" %}
@@ -24,7 +24,7 @@ build:
   number: {{ build }}
   string: {{ scalar }}_h{{ PKG_HASH }}_{{ build }}
   run_exports:
-    - {{ pin_subpackage('petsc', max_pin='x.x') }}
+    - {{ pin_subpackage('petsc', max_pin='x.x') }} {{ scalar }}_*
   track_features:
     - petsc_complex  # [scalar == "complex"]
 


### PR DESCRIPTION
otherwise something built against real can try to run with complex, which will fail.

Just found this in https://github.com/conda-forge/fenics-dolfinx-feedstock/pull/14 where I only specified the scalar variant in the host dependencies (should be all that's required), but it pulled in `real` for the test env after building with `complex`, causing missing symbols
