### PR TITLE
Rerender with clang 16

### DIFF
--- a/.ci_support/migrations/hdf51141.yaml
+++ b/.ci_support/migrations/hdf51141.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-hdf5:
-- 1.14.1
-migrator_ts: 1687165815.3104627

--- a/.ci_support/osx_64_mpimpichscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichscalarcomplex.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/osx_64_mpimpichscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichscalarreal.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/osx_64_mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpiscalarcomplex.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/osx_64_mpiopenmpiscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpiscalarreal.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/osx_arm64_mpimpichscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichscalarcomplex.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/osx_arm64_mpimpichscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichscalarreal.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/osx_arm64_mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpiscalarcomplex.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/osx_arm64_mpiopenmpiscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpiscalarreal.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,7 +34,7 @@ CONDARC
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
     pip mamba conda-build boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup
+    pip mamba conda-build boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -26,7 +26,7 @@ conda activate base
 mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
     pip mamba conda-build boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup
+    pip mamba conda-build boa conda-forge-ci-setup=3
 
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.20.0" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 {% set mpi = mpi or 'mpich' %}
 {% if scalar == "real" %}

--- a/recipe/mpiexec.sh
+++ b/recipe/mpiexec.sh
@@ -9,6 +9,7 @@ fi
 if command -v "${PREFIX}/bin/ompi_info" >/dev/null; then
     export OMPI_MCA_plm=isolated
     export OMPI_MCA_rmaps_base_oversubscribe=yes
+    export OMPI_MCA_btl=tcp,self
     export OMPI_MCA_btl_vader_single_copy_mechanism=none
     mpiexec="mpiexec --allow-run-as-root"
 fi


### PR DESCRIPTION
After clang 16 started rolling out, some downstream packages started failing with errors like:

```
ld: file not found: /usr/lib/system/libsystem_network.dylib for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

which I don't really understand, but I _suspect_ is in some over-linking of dependencies (not sure where the culprit is). I think maybe upgrading the compiler petsc itself is built with will help.