### PR TITLE
restore mpi version range checks

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.22.0" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 {% set mpi = mpi or 'mpich' %}
 {% if scalar == "real" %}
@@ -28,6 +28,7 @@ source:
     - ignore-not-invalid.patch
     - no-cppflags-in-pkgconfig-cflags.patch
     - target-cudadir.patch
+    - mr7912.patch
 
 build:
   skip: true  # [win]

--- a/recipe/mr7912.patch
+++ b/recipe/mr7912.patch
@@ -1,0 +1,27 @@
+diff --git a/include/petscsys.h b/include/petscsys.h
+index 7992b80a362..dbcf3d89057 100644
+--- a/include/petscsys.h
++++ b/include/petscsys.h
+@@ -91,14 +91,18 @@
+ #elif defined(PETSC_HAVE_MPICH)
+   #if !defined(MPICH_NUMVERSION) || defined(MVAPICH2_NUMVERSION) || defined(I_MPI_NUMVERSION)
+     #error "PETSc was configured with MPICH but now appears to be compiling using a non-MPICH mpi.h"
+-  #elif !PETSC_PKG_MPICH_VERSION_EQ(MPICH_NUMVERSION / 10000000, MPICH_NUMVERSION / 100000 % 100, MPICH_NUMVERSION / 1000 % 100)
+-    #error "PETSc was configured with one MPICH mpi.h version but now appears to be compiling using a different MPICH mpi.h version"
++  #elif PETSC_PKG_MPICH_VERSION_GT(MPICH_NUMVERSION / 10000000, MPICH_NUMVERSION / 100000 % 100, MPICH_NUMVERSION / 1000 % 100)
++    #error "PETSc was configured with one MPICH mpi.h version but now appears to be compiling using an older MPICH mpi.h version"
++  #elif PETSC_PKG_MPICH_VERSION_LT(MPICH_NUMVERSION / 10000000, 0, 0)
++    #error "PETSc was configured with one MPICH mpi.h version but now appears to be compiling using a newer major MPICH mpi.h version"
+   #endif
+ #elif defined(PETSC_HAVE_OPENMPI)
+   #if !defined(OMPI_MAJOR_VERSION)
+     #error "PETSc was configured with Open MPI but now appears to be compiling using a non-Open MPI mpi.h"
+-  #elif !PETSC_PKG_OPENMPI_VERSION_EQ(OMPI_MAJOR_VERSION, OMPI_MINOR_VERSION, OMPI_RELEASE_VERSION)
+-    #error "PETSc was configured with one Open MPI mpi.h version but now appears to be compiling using a different Open MPI mpi.h version"
++  #elif PETSC_PKG_OPENMPI_VERSION_GT(OMPI_MAJOR_VERSION, OMPI_MINOR_VERSION, OMPI_RELEASE_VERSION)
++    #error "PETSc was configured with one Open MPI mpi.h version but now appears to be compiling using an older Open MPI mpi.h version"
++  #elif PETSC_PKG_OPENMPI_VERSION_LT(OMPI_MAJOR_VERSION, 0, 0)
++    #error "PETSc was configured with one Open MPI mpi.h version but now appears to be compiling using a newer major Open MPI mpi.h version"
+   #endif
+ #elif defined(PETSC_HAVE_MSMPI_VERSION)
+   #if !defined(MSMPI_VER)


### PR DESCRIPTION
apparently lost upstream

upstream PR: https://gitlab.com/petsc/petsc/-/merge_requests/7912
