### PR TITLE
remove some redundant/outdated runtime dependency pins

### DIFF
--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpimpichscalarcomplex.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.8
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - complex
 suitesparse:

--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpimpichscalarreal.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpimpichscalarreal.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.8
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - real
 suitesparse:

--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpiopenmpiscalarcomplex.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.8
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - complex
 suitesparse:

--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpiopenmpiscalarreal.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.8
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - real
 suitesparse:

--- a/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpimpichscalarcomplex.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - complex
 suitesparse:

--- a/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpimpichscalarreal.yaml
+++ b/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpimpichscalarreal.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - real
 suitesparse:

--- a/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpiopenmpiscalarcomplex.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - complex
 suitesparse:

--- a/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpiopenmpiscalarreal.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - real
 suitesparse:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpimpichscalarcomplex.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - complex
 suitesparse:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpimpichscalarreal.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpimpichscalarreal.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - real
 suitesparse:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpiopenmpiscalarcomplex.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - complex
 suitesparse:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpiopenmpiscalarreal.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - real
 suitesparse:

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpimpichscalarcomplex.yaml
@@ -26,6 +26,8 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.8
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -52,11 +54,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - complex
 suitesparse:

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpimpichscalarreal.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpimpichscalarreal.yaml
@@ -26,6 +26,8 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.8
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -52,11 +54,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - real
 suitesparse:

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpiopenmpiscalarcomplex.yaml
@@ -26,6 +26,8 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.8
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -52,11 +54,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - complex
 suitesparse:

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpiopenmpiscalarreal.yaml
@@ -26,6 +26,8 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.8
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -52,11 +54,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - real
 suitesparse:

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpimpichscalarcomplex.yaml
@@ -26,6 +26,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -52,11 +54,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - complex
 suitesparse:

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpimpichscalarreal.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpimpichscalarreal.yaml
@@ -26,6 +26,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -52,11 +54,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - real
 suitesparse:

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpiopenmpiscalarcomplex.yaml
@@ -26,6 +26,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -52,11 +54,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - complex
 suitesparse:

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpiopenmpiscalarreal.yaml
@@ -26,6 +26,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -52,11 +54,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - real
 suitesparse:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpimpichscalarcomplex.yaml
@@ -26,6 +26,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -52,11 +54,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - complex
 suitesparse:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpimpichscalarreal.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpimpichscalarreal.yaml
@@ -26,6 +26,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -52,11 +54,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - real
 suitesparse:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpiopenmpiscalarcomplex.yaml
@@ -26,6 +26,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -52,11 +54,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - complex
 suitesparse:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpiopenmpiscalarreal.yaml
@@ -26,6 +26,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -52,11 +54,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - real
 suitesparse:

--- a/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpimpichscalarcomplex.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.8
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - complex
 suitesparse:

--- a/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpimpichscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpimpichscalarreal.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.8
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - real
 suitesparse:

--- a/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpiopenmpiscalarcomplex.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.8
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - complex
 suitesparse:

--- a/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11mpiopenmpiscalarreal.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.8
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - real
 suitesparse:

--- a/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpimpichscalarcomplex.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - complex
 suitesparse:

--- a/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpimpichscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpimpichscalarreal.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - real
 suitesparse:

--- a/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpiopenmpiscalarcomplex.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - complex
 suitesparse:

--- a/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12mpiopenmpiscalarreal.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - real
 suitesparse:

--- a/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpimpichscalarcomplex.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - complex
 suitesparse:

--- a/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpimpichscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpimpichscalarreal.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - real
 suitesparse:

--- a/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpiopenmpiscalarcomplex.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - complex
 suitesparse:

--- a/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13mpiopenmpiscalarreal.yaml
@@ -22,6 +22,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -48,11 +50,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x
 scalar:
 - real
 suitesparse:

--- a/.ci_support/osx_64_mpimpichscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpimpichscalarcomplex.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -50,11 +52,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x.x
 scalar:
 - complex
 suitesparse:

--- a/.ci_support/osx_64_mpimpichscalarreal.yaml
+++ b/.ci_support/osx_64_mpimpichscalarreal.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -50,11 +52,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x.x
 scalar:
 - real
 suitesparse:

--- a/.ci_support/osx_64_mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/osx_64_mpiopenmpiscalarcomplex.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -50,11 +52,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x.x
 scalar:
 - complex
 suitesparse:

--- a/.ci_support/osx_64_mpiopenmpiscalarreal.yaml
+++ b/.ci_support/osx_64_mpiopenmpiscalarreal.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -50,11 +52,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x.x
 scalar:
 - real
 suitesparse:

--- a/.ci_support/osx_arm64_mpimpichscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpimpichscalarcomplex.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -50,11 +52,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x.x
 scalar:
 - complex
 suitesparse:

--- a/.ci_support/osx_arm64_mpimpichscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpimpichscalarreal.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -50,11 +52,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x.x
 scalar:
 - real
 suitesparse:

--- a/.ci_support/osx_arm64_mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpiscalarcomplex.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -50,11 +52,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x.x
 scalar:
 - complex
 suitesparse:

--- a/.ci_support/osx_arm64_mpiopenmpiscalarreal.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpiscalarreal.yaml
@@ -22,6 +22,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -50,11 +52,6 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-pin_run_as_build:
-  metis:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x.x
 scalar:
 - real
 suitesparse:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ stages:
           echo "##vso[task.setvariable variable=log]$git_log"
         displayName: Obtain commit message
       - bash: echo "##vso[task.setvariable variable=RET]false"
-        condition: or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]'))
+        condition: and(eq(variables['Build.Reason'], 'PullRequest'), or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]')))
         displayName: Skip build?
       - bash: echo "##vso[task.setvariable variable=start_main;isOutput=true]$RET"
         name: result

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,15 +6,3 @@ scalar:
   - real
   - complex
 
-pin_run_as_build:
-  hypre:
-    max_pin: x.x.x
-  metis:
-    max_pin: x.x
-  parmetis:
-    max_pin: x.x
-  scalapack:
-    max_pin: x.x
-  suitesparse:
-    max_pin: x.x  # [not osx]
-    max_pin: x.x.x  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,7 +74,6 @@ requirements:
     - {{ mpi }}  # [mpi == 'openmpi' and build_platform != target_platform]
   host:
     - libblas
-    - libcblas
     - liblapack
     - cmake
     - {{ mpi }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.22.1" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 {% set mpi = mpi or 'mpich' %}
 {% if scalar == "real" %}
@@ -91,6 +91,7 @@ requirements:
     - suitesparse
     - hdf5
     - hdf5 * mpi_{{ mpi }}_*
+    - fftw
     - fftw * mpi_{{ mpi }}_*
     - cuda-version {{ cuda_compiler_version }}  # [cuda_compiler_version != "None"]
     - cudatoolkit                               # [(cuda_compiler_version or "").startswith("11")]
@@ -104,21 +105,6 @@ requirements:
     - libcusparse-dev
     {% endif %}
   run:
-    - {{ mpi }}
-    - yaml
-    - hypre
-    - metis
-    - parmetis
-    - libptscotch
-    - scalapack
-    - superlu
-    - superlu_dist
-    - libscotch
-    - mumps-mpi
-    - suitesparse
-    - hdf5
-    - hdf5 * mpi_{{ mpi }}_*
-    - fftw * mpi_{{ mpi }}_*
     - cuda-version >={{ cuda_major }}.2,<{{ cuda_major+1 }}  # [(cuda_compiler_version or "").startswith("11")]
     - cudatoolkit >={{ cuda_major }}.2,<{{ cuda_major+1 }}   # [(cuda_compiler_version or "").startswith("11")]
     {% if cuda_major >= 12 %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -104,6 +104,9 @@ requirements:
     - libcusparse-dev
     {% endif %}
   run:
+    # superlu 5.2.2 is a static lib
+    # remove this when it's updated to a shared lib
+    - {{ pin_compatible("superlu", max_pin="x.x.x") }}
     - cuda-version >={{ cuda_major }}.2,<{{ cuda_major+1 }}  # [(cuda_compiler_version or "").startswith("11")]
     - cudatoolkit >={{ cuda_major }}.2,<{{ cuda_major+1 }}   # [(cuda_compiler_version or "").startswith("11")]
     {% if cuda_major >= 12 %}


### PR DESCRIPTION
run_exports in dependencies should take care of these. Need to make sure to inspect the linkage checks in the build output before merging, since those usually produce warnings not errors. In particular, hypre, scalapack, and parmetis only got their run_exports today. I'll leave this as draft until I've looked at the build output to make sure it's right.

manual rewriting of cuda pins is left alone, though I'm not sure we should keep it. I'll let that be its own discussion of whether it's worth petsc being different from everything else.