### PR TITLE
suitesparse libraries

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -40,38 +40,6 @@ jobs:
       : CONFIG: linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpiopenmpiscalarreal
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64-cuda11.8:cos7
-      ? linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpimpichscalarcomplex
-      : CONFIG: linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpimpichscalarcomplex
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
-      ? linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpimpichscalarreal
-      : CONFIG: linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpimpichscalarreal
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
-      ? linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpiopenmpiscalarcomplex
-      : CONFIG: linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpiopenmpiscalarcomplex
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
-      ? linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpiopenmpiscalarreal
-      : CONFIG: linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpiopenmpiscalarreal
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
-      ? linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpimpichscalarcomplex
-      : CONFIG: linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpimpichscalarcomplex
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
-      ? linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpimpichscalarreal
-      : CONFIG: linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpimpichscalarreal
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
-      ? linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpiopenmpiscalarcomplex
-      : CONFIG: linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpiopenmpiscalarcomplex
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
-      ? linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpiopenmpiscalarreal
-      : CONFIG: linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpiopenmpiscalarreal
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
       ? linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex
       : CONFIG: linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex
         UPLOAD_PACKAGES: 'True'
@@ -102,6 +70,38 @@ jobs:
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
       ? linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal
       : CONFIG: linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
+      ? linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex
+      : CONFIG: linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
+      ? linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarreal
+      : CONFIG: linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarreal
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
+      ? linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarcomplex
+      : CONFIG: linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarcomplex
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
+      ? linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarreal
+      : CONFIG: linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarreal
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
+      ? linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarcomplex
+      : CONFIG: linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarcomplex
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
+      ? linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarreal
+      : CONFIG: linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarreal
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
+      ? linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarcomplex
+      : CONFIG: linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarcomplex
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
+      ? linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal
+      : CONFIG: linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
       ? linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpimpichscalarcomplex
@@ -136,38 +136,6 @@ jobs:
       : CONFIG: linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpiopenmpiscalarreal
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64-cuda11.8:ubi8
-      ? linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpimpichscalarcomplex
-      : CONFIG: linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpimpichscalarcomplex
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
-      ? linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpimpichscalarreal
-      : CONFIG: linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpimpichscalarreal
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
-      ? linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpiopenmpiscalarcomplex
-      : CONFIG: linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpiopenmpiscalarcomplex
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
-      ? linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpiopenmpiscalarreal
-      : CONFIG: linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpiopenmpiscalarreal
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
-      ? linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpimpichscalarcomplex
-      : CONFIG: linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpimpichscalarcomplex
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
-      ? linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpimpichscalarreal
-      : CONFIG: linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpimpichscalarreal
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
-      ? linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpiopenmpiscalarcomplex
-      : CONFIG: linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpiopenmpiscalarcomplex
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
-      ? linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpiopenmpiscalarreal
-      : CONFIG: linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpiopenmpiscalarreal
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
       ? linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex
       : CONFIG: linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex
         UPLOAD_PACKAGES: 'True'
@@ -198,6 +166,38 @@ jobs:
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
       ? linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal
       : CONFIG: linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
+      ? linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex
+      : CONFIG: linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
+      ? linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarreal
+      : CONFIG: linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarreal
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
+      ? linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarcomplex
+      : CONFIG: linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarcomplex
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
+      ? linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarreal
+      : CONFIG: linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarreal
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
+      ? linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarcomplex
+      : CONFIG: linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarcomplex
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
+      ? linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarreal
+      : CONFIG: linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarreal
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
+      ? linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarcomplex
+      : CONFIG: linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarcomplex
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
+      ? linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal
+      : CONFIG: linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
       ? linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpimpichscalarcomplex

--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpimpichscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpimpichscalarreal.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpimpichscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpiopenmpiscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpiopenmpiscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpimpichscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpimpichscalarreal.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpimpichscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpiopenmpiscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpiopenmpiscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarreal.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarreal.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -19,7 +19,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 fftw:
@@ -27,17 +27,27 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '12'
+- '13'
 hdf5:
-- 1.14.4
+- 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarreal.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarreal.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -19,7 +19,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 fftw:
@@ -27,17 +27,27 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '12'
+- '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,16 +58,12 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarcomplex.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -19,7 +19,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 fftw:
@@ -27,17 +27,27 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '12'
+- '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,16 +58,12 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
-- real
-suitesparse:
-- '7'
+- complex
 superlu_dist:
 - '9'
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarreal.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -19,7 +19,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 fftw:
@@ -27,17 +27,27 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '12'
+- '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
-- complex
-suitesparse:
-- '7'
+- real
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarcomplex.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -19,7 +19,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 fftw:
@@ -27,17 +27,27 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '12'
+- '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
-- real
-suitesparse:
-- '7'
+- complex
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarreal.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarreal.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -19,7 +19,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 fftw:
@@ -27,33 +27,39 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '12'
+- '13'
 hdf5:
-- 1.14.3
+- 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
-- openmpi
+- mpich
 mpich:
 - '4'
 mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarcomplex.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -19,7 +19,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 fftw:
@@ -27,17 +27,27 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '12'
+- '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -19,7 +19,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 fftw:
@@ -27,17 +27,27 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '12'
+- '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,16 +58,12 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpimpichscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpimpichscalarreal.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpimpichscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpiopenmpiscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpiopenmpiscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpimpichscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpimpichscalarreal.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpimpichscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpiopenmpiscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpiopenmpiscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarreal.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarreal.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -19,7 +19,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 fftw:
@@ -27,37 +27,43 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '12'
+- '13'
 hdf5:
-- 1.14.4
+- 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
-- openmpi
+- mpich
 mpich:
 - '4'
 mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
-- real
-suitesparse:
-- '7'
+- complex
 superlu_dist:
 - '9'
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarreal.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarreal.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -19,7 +19,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 fftw:
@@ -27,33 +27,39 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '12'
+- '13'
 hdf5:
-- 1.14.4
+- 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
-- openmpi
+- mpich
 mpich:
 - '4'
 mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
-- complex
-suitesparse:
-- '7'
+- real
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarcomplex.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -19,7 +19,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 fftw:
@@ -27,37 +27,43 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '12'
+- '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
-- mpich
+- openmpi
 mpich:
 - '4'
 mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarreal.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -19,7 +19,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 fftw:
@@ -27,33 +27,39 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '12'
+- '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
-- mpich
+- openmpi
 mpich:
 - '4'
 mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
-- complex
-suitesparse:
-- '7'
+- real
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarcomplex.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -19,7 +19,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 fftw:
@@ -27,17 +27,27 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '12'
+- '13'
 hdf5:
-- 1.14.3
+- 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,16 +58,12 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
-- real
-suitesparse:
-- '7'
+- complex
 superlu_dist:
 - '9'
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarreal.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarreal.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -19,7 +19,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 fftw:
@@ -27,33 +27,39 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '12'
+- '13'
 hdf5:
-- 1.14.3
+- 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
-- openmpi
+- mpich
 mpich:
 - '4'
 mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
-- complex
-suitesparse:
-- '7'
+- real
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarcomplex.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -19,7 +19,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 fftw:
@@ -27,33 +27,39 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '12'
+- '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
-- mpich
+- openmpi
 mpich:
 - '4'
 mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
-- real
-suitesparse:
-- '7'
+- complex
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '12'
+- '13'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -19,7 +19,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '12'
+- '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 fftw:
@@ -27,33 +27,39 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '12'
+- '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
-- mpich
+- openmpi
 mpich:
 - '4'
 mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
-- complex
-suitesparse:
-- '7'
+- real
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpimpichscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpimpichscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpimpichscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpiopenmpiscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.3mpiopenmpiscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpimpichscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpimpichscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpimpichscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpiopenmpiscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11fortran_compiler_version11hdf51.14.4mpiopenmpiscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '11'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpimpichscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '12'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpimpichscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpimpichscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '12'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpiopenmpiscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '12'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpiopenmpiscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '12'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpimpichscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '12'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpimpichscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpimpichscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '12'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpiopenmpiscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '12'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.4cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpiopenmpiscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '12'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 metis:
 - 5.1.0
 mpi:
@@ -48,12 +58,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/osx_64_hdf51.14.3mpimpichscalarcomplex.yaml
+++ b/.ci_support/osx_64_hdf51.14.3mpimpichscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
@@ -50,12 +60,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/osx_64_hdf51.14.3mpimpichscalarreal.yaml
+++ b/.ci_support/osx_64_hdf51.14.3mpimpichscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
@@ -50,12 +60,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/osx_64_hdf51.14.3mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/osx_64_hdf51.14.3mpiopenmpiscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
@@ -50,12 +60,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/osx_64_hdf51.14.3mpiopenmpiscalarreal.yaml
+++ b/.ci_support/osx_64_hdf51.14.3mpiopenmpiscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
@@ -50,12 +60,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/osx_64_hdf51.14.4mpimpichscalarcomplex.yaml
+++ b/.ci_support/osx_64_hdf51.14.4mpimpichscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
@@ -50,12 +60,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/osx_64_hdf51.14.4mpimpichscalarreal.yaml
+++ b/.ci_support/osx_64_hdf51.14.4mpimpichscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
@@ -50,12 +60,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/osx_64_hdf51.14.4mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/osx_64_hdf51.14.4mpiopenmpiscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
@@ -50,12 +60,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/osx_64_hdf51.14.4mpiopenmpiscalarreal.yaml
+++ b/.ci_support/osx_64_hdf51.14.4mpiopenmpiscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
@@ -50,12 +60,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/osx_arm64_hdf51.14.3mpimpichscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.3mpimpichscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 macos_machine:
 - arm64-apple-darwin20.0.0
 metis:
@@ -50,12 +60,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/osx_arm64_hdf51.14.3mpimpichscalarreal.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.3mpimpichscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 macos_machine:
 - arm64-apple-darwin20.0.0
 metis:
@@ -50,12 +60,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/osx_arm64_hdf51.14.3mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.3mpiopenmpiscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 macos_machine:
 - arm64-apple-darwin20.0.0
 metis:
@@ -50,12 +60,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/osx_arm64_hdf51.14.3mpiopenmpiscalarreal.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.3mpiopenmpiscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.3
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 macos_machine:
 - arm64-apple-darwin20.0.0
 metis:
@@ -50,12 +60,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/osx_arm64_hdf51.14.4mpimpichscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.4mpimpichscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 macos_machine:
 - arm64-apple-darwin20.0.0
 metis:
@@ -50,12 +60,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/osx_arm64_hdf51.14.4mpimpichscalarreal.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.4mpimpichscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 macos_machine:
 - arm64-apple-darwin20.0.0
 metis:
@@ -50,12 +60,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/osx_arm64_hdf51.14.4mpiopenmpiscalarcomplex.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.4mpiopenmpiscalarcomplex.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 macos_machine:
 - arm64-apple-darwin20.0.0
 metis:
@@ -50,12 +60,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - complex
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/.ci_support/osx_arm64_hdf51.14.4mpiopenmpiscalarreal.yaml
+++ b/.ci_support/osx_arm64_hdf51.14.4mpiopenmpiscalarreal.yaml
@@ -30,14 +30,24 @@ fortran_compiler_version:
 - '13'
 hdf5:
 - 1.14.4
+libamd:
+- '3'
 libblas:
 - 3.9 *netlib
+libcholmod:
+- '5'
+libklu:
+- '2'
 liblapack:
 - 3.9 *netlib
 libptscotch:
 - 7.0.5
 libscotch:
 - 7.0.5
+libspqr:
+- '4'
+libumfpack:
+- '6'
 macos_machine:
 - arm64-apple-darwin20.0.0
 metis:
@@ -50,12 +60,8 @@ mumps_mpi:
 - 5.7.3
 openmpi:
 - '5'
-petsc:
-- '3.21'
 scalar:
 - real
-suitesparse:
-- '7'
 superlu_dist:
 - '9'
 target_platform:

--- a/README.md
+++ b/README.md
@@ -87,62 +87,6 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpimpichscalarcomplex</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpimpichscalarcomplex" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpimpichscalarreal</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpimpichscalarreal" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpiopenmpiscalarcomplex</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpiopenmpiscalarcomplex" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpiopenmpiscalarreal</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpiopenmpiscalarreal" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpimpichscalarcomplex</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpimpichscalarcomplex" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpimpichscalarreal</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpimpichscalarreal" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpiopenmpiscalarcomplex</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpiopenmpiscalarcomplex" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpiopenmpiscalarreal</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpiopenmpiscalarreal" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
@@ -196,6 +140,62 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarreal</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarreal" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarcomplex</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarcomplex" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarreal</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarreal" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarcomplex</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarcomplex" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarreal</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarreal" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarcomplex</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarcomplex" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -255,62 +255,6 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpimpichscalarcomplex</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpimpichscalarcomplex" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpimpichscalarreal</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpimpichscalarreal" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpiopenmpiscalarcomplex</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpiopenmpiscalarcomplex" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpiopenmpiscalarreal</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.3mpiopenmpiscalarreal" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpimpichscalarcomplex</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpimpichscalarcomplex" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpimpichscalarreal</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpimpichscalarreal" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpiopenmpiscalarcomplex</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpiopenmpiscalarcomplex" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpiopenmpiscalarreal</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version12fortran_compiler_version12hdf51.14.4mpiopenmpiscalarreal" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
@@ -364,6 +308,62 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version13cuda_compilerNonecuda_compiler_versionNonecxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarcomplex" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarreal</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpimpichscalarreal" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarcomplex</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarcomplex" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarreal</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.3mpiopenmpiscalarreal" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarcomplex</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarcomplex" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarreal</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpimpichscalarreal" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarcomplex</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarcomplex" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=771&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/petsc-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13fortran_compiler_version13hdf51.14.4mpiopenmpiscalarreal" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.22.2" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 # make sure things are defined during conda-smithy operations
 # These will never be undefined during build
@@ -94,7 +94,14 @@ requirements:
     - superlu_dist
     - libscotch
     - mumps-mpi
-    - suitesparse
+
+    # suitesparse
+    - libamd
+    - libcholmod
+    - libklu
+    - libspqr
+    - libumfpack
+
     - hdf5
     - hdf5 * mpi_{{ mpi }}_*
     - fftw


### PR DESCRIPTION
each suitesparse library now has its own package name, so we can depend directly on what we use, rather than all of suitesparse