### PR TITLE
Build with "--with-openmp"

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,7 +12,6 @@ unset F77
 # unset CC
 unset CXX
 if [[ "$target_platform" == linux-* ]]; then
-    export LDFLAGS="-pthread -fopenmp $LDFLAGS"
     export LDFLAGS="$LDFLAGS -Wl,-rpath-link,$PREFIX/lib"
     # --as-needed appears to cause problems with fortran compiler detection
     # due to missing libquadmath
@@ -101,7 +100,8 @@ python ./configure \
   --with-yaml=1 \
   --with-hdf5=1 \
   --with-fftw=1 \
-  --with-hwloc=0 \
+  --with-hwloc=1 \
+  --with-openmp=1 \
   --with-hypre=1 \
   --with-metis=1 \
   --with-mpi=1 \

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   version: 3.22.3
-  build: 101
+  build: 102
   # these variables should all be overridden in variant files
   # but default values are sometimes needed for conda-smithy rerender
   mpi: ${{ mpi | default('mpich') }}

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -72,6 +72,7 @@ requirements:
     - ${{ mpi }}
     - yaml
     - hypre
+    - libhwloc
     - metis
     - parmetis
     - libptscotch


### PR DESCRIPTION
This adds "--with-openmp" to the petsc configuration, as discussed in #230 .

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
