### PR TITLE
try to fix scrubbed absolute paths

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   version: "3.23.0"
-  build: 0
+  build: 1
   # these variables should all be overridden in variant files
   # but default values are sometimes needed for conda-smithy rerender
   mpi: ${{ mpi | default('mpich') }}


### PR DESCRIPTION
- replace $BUILD_PREFIX/bin/foo with foo so they resolve on $PATH, instead of hardcoding a patht hat won't exist (we did $PREFIX/bin before, but that is also wrong)
- leave cuda paths alone alone instead of rewriting $PREFIX/target/arch/include to $PREFIX, which is why slepc needed cuda includes
- dump petscvariables before/after for inspection/debugging

hopefully closes #240 

I was able to build cuda builds (both 11 and 12) of slepc locally with this, entirely removing the cuda stuff from slepc's build.sh, which I think is right